### PR TITLE
docs: fix simple typo, unisgned -> unsigned

### DIFF
--- a/include/capi/cef_v8_capi.h
+++ b/include/capi/cef_v8_capi.h
@@ -370,7 +370,7 @@ typedef struct _cef_v8value_t {
   int32 (CEF_CALLBACK *get_int_value)(struct _cef_v8value_t* self);
 
   ///
-  // Return an unisgned int value.  The underlying data will be converted to if
+  // Return an unsigned int value.  The underlying data will be converted to if
   // necessary.
   ///
   uint32 (CEF_CALLBACK *get_uint_value)(struct _cef_v8value_t* self);


### PR DESCRIPTION
There is a small typo in include/capi/cef_v8_capi.h.

Should read `unsigned` rather than `unisgned`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md